### PR TITLE
fixing test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 h5py>=3.0.0
+git+https://github.com/oda-hub/dispatcher-app.git@updated_dataserver_monitor-always-from-work_dir#egg=cdci_data_analysis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 h5py>=3.0.0
-git+https://github.com/oda-hub/dispatcher-app.git@updated_dataserver_monitor-always-from-work_dir#egg=cdci_data_analysis

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -49,7 +49,7 @@ def test_discover_plugin():
 
 def test_gw(dispatcher_live_fixture, httpserver, product):
     server = dispatcher_live_fixture
-    with open(f'tests/mock_backend_json/response_{product}.json', 'r') as fd:
+    with open(f'mock_backend_json/response_{product}.json', 'r') as fd:
         respjson = json.loads(fd.read())
     httpserver.expect_ordered_request('/').respond_with_data('')    
     httpserver.expect_ordered_request(f'/api/v1.0/get/{product}').respond_with_json({'comment': "task created", "workflow_status": "submitted"}, status=201)
@@ -82,7 +82,7 @@ def test_gw(dispatcher_live_fixture, httpserver, product):
     
     d = requests.get(server + "/download_products",
                     params = {
-                        'session_id': jdata['job_monitor']['session_id'],
+                        'session_id': jdata['session_id'],
                         'download_file_name': jdata['products']['download_file_name'],
                         'file_list': jdata['products']['file_name'],
                         'query_status': 'ready',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import logging
+import os
 
 import pytest
 import h5py
@@ -49,7 +50,7 @@ def test_discover_plugin():
 
 def test_gw(dispatcher_live_fixture, httpserver, product):
     server = dispatcher_live_fixture
-    with open(f'mock_backend_json/response_{product}.json', 'r') as fd:
+    with open(os.path.join(os.path.dirname(__file__), f'mock_backend_json/response_{product}.json'), 'r') as fd:
         respjson = json.loads(fd.read())
     httpserver.expect_ordered_request('/').respond_with_data('')    
     httpserver.expect_ordered_request(f'/api/v1.0/get/{product}').respond_with_json({'comment': "task created", "workflow_status": "submitted"}, status=201)


### PR DESCRIPTION
Reason of https://github.com/oda-hub/dispatcher-app/actions/runs/9129792580/job/25107407557?pr=680 is because for submitting the `download_products` request, the wrong `session_id` was used.

In particular, the one used was the one from the job_monitor (`jdata['job_monitor']['session_id']`), when the one to use the one of the request itself (`jdata['session_id']`).

It happens now because of the change introduced with https://github.com/oda-hub/dispatcher-app/pull/680

The job monitor session id one refers to the scratch dir of the first request, where the file to download is not present.